### PR TITLE
add Cython versions of functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 __pycache__
 *.out
+/*.c
+*.so
 Dump/
+/build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+all:
+	python3 setup.py build_ext --inplace

--- a/lj_functions_c.pyx
+++ b/lj_functions_c.pyx
@@ -1,0 +1,88 @@
+import numpy as np
+cimport numpy as np
+import cython
+from libc.math cimport sqrt, round
+
+
+cdef struct Sp:
+    double eps
+    double sigma
+    double rc
+    int N
+    double L
+    double dt
+    int Nt
+    int thermo
+    int seed
+    bint dump
+    bint use_numba
+    bint use_cython
+
+
+@cython.boundscheck(False)
+cdef double norm(double[:] v):
+    cdef double result = 0.
+    for i in range(v.shape[0]):
+        result += v[i]*v[i]
+    return sqrt(result)
+
+
+@cython.cdivision(True)
+cdef double V_LJ(double mag_r, Sp sp):
+    V_rc = 4 * sp.eps * ((sp.sigma / sp.rc) ** 12 - (sp.sigma / sp.rc) ** 6)
+    return 4 * sp.eps * ((sp.sigma / mag_r) ** 12 - (sp.sigma / mag_r) ** 6) - \
+        V_rc if mag_r < sp.rc else 0.0
+
+
+@cython.boundscheck(False)
+@cython.cdivision(True)
+cdef void force(double[:] r, Sp sp, double[:] result):
+    mag_dr = norm(r)
+    for i in range(3):
+        result[i] = 4 * sp.eps * (-12 * (sp.sigma / mag_dr) ** 12  + 6 * (sp.sigma / mag_dr) ** 6) * r[i] / mag_dr**2 \
+        if mag_dr < sp.rc else 0.
+
+
+@cython.boundscheck(False)
+def tot_PE(double[:, :] pos_list, Sp sp):
+    cdef double E = 0.
+    cdef int N = pos_list.shape[0]
+    cdef double[:] diff = np.zeros((3,))
+    cdef int i, j, k
+    for i in range(N):
+        for j in range(i + 1, N):
+            for k in range(3):
+                diff[k] = pos_list[i, k] - pos_list[j, k]
+            E += V_LJ(norm(diff), sp)
+    return E
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def force_list(double[:, :] pos_list, Sp sp):
+    cdef int N = pos_list.shape[0]
+    cdef double[:, :, :] force_mat = np.zeros((N, N, 3))
+    cdef double[:, :] cell = sp.L*np.eye(3)
+    cdef double[:, :] inv_cell = np.linalg.pinv(cell)
+    cdef double[:] dr = np.zeros((3,))
+    cdef double[:] dr_n = np.zeros((3,))
+    cdef double[:] G = np.zeros((3,))
+    cdef double[:] G_n = np.zeros((3,))
+    cdef int i, j, k, l
+    for i in range(N):
+        for j in range(i):
+            for k in range(3):
+                dr[k] = pos_list[j, k] - pos_list[i, k]
+            G[:] = 0.
+            for k in range(3):
+                for l in range(3):
+                    G[k] += inv_cell[k, l]*dr[l]
+            for k in range(3):
+                G_n[k] = G[k] - round(G[k])
+            dr_n[:] = 0.
+            for k in range(3):
+                for l in range(3):
+                    dr_n[k] += cell[k, l]*G_n[l]
+            force(dr_n, sp, force_mat[i, j, :])
+    force_mat -= np.transpose(force_mat, (1, 0, 2))
+    return np.sum(force_mat, axis=1)

--- a/lj_sim.py
+++ b/lj_sim.py
@@ -3,7 +3,7 @@
 Simulation of LJ clusters in a box w pbc
 
 Usage: lj_sim.py <L> <rho> [--T <T>] [--Nt <Nt>] [--dt <dt>]
-                 [--thermo <th>] [--dump] [--numba]
+                 [--thermo <th>] [--dump] [--numba | --cython]
 
 Options:
     --T <T>             Temperature [default: 1.0]
@@ -11,6 +11,7 @@ Options:
     --dt <dt>           Timestep [default: 0.002]
     --thermo <th>       Print output this many times [default: 10]
     --numba             Use Numba versions of functions
+    --cython            Use Cyton versions of functions
 
 02/04/16
 """
@@ -49,7 +50,7 @@ if __name__ == "__main__":
 
     sp = mydict(eps=eps, sigma=sigma, rc=rc, N=N, L=L, dt=dt, Nt=Nt,
                 thermo=thermo, seed=seed, dump=args["--dump"],
-                use_numba=args["--numba"])  # system params
+                use_numba=args["--numba"], use_cython=args['--cython'])  # system params
 
     print(" =========== \n LJ clusters \n ===========")
     print("Particles: %i | Temp: %f | Steps: %i | dt: %f | thermo: %i"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from distutils.core import setup
+from distutils.extension import Extension
+from Cython.Build import cythonize
+import numpy
+
+extensions = [
+    Extension('*', ['*.pyx'],
+              include_dirs=[numpy.get_include()])
+]
+setup(
+    ext_modules=cythonize(extensions),
+)


### PR DESCRIPTION
This seems even faster than Numba. Which is weird though, because optimized Numba code should typically give abut the same speed as Cython. So we're probably missing something in the Numba implementation. Also, writing the Cython code was a horror compared to Numba.

Compile with `make`.

**Pure Python**

```
🐟 03:32 her@air ~/va/Re/ljsim master env TIMING=1 NUMBA_DISABLE_JIT=1 time ./lj_sim.py 12 .04
 =========== 
 LJ clusters 
 ===========
Particles: 69 | Temp: 1.000000 | Steps: 100 | dt: 0.002000 | thermo: 10
...
integrate      20.5806
    force_list 14.6456
    tot_PE     5.9090 
init           0.1729 
    tot_PE     0.1726 
       21.18 real        19.87 user         0.26 sys
```

**Numba**

```
🐟 03:41 her@air ~/va/Re/ljsim master env TIMING=1 time ./lj_sim.py 12 .04 --numba
 =========== 
 LJ clusters 
 ===========
Particles: 69 | Temp: 1.000000 | Steps: 100 | dt: 0.002000 | thermo: 10
integrate      1.0484
    force_list 0.8748
    tot_PE     0.1476
init           0.0045
    tot_PE     0.0043
        3.69 real         3.22 user         0.20 sys
```

**Cython**

```
🐟 03:53 her@air ~/va/Re/ljsim cython env TIMING=1 NUMBA_DISABLE_JIT=1 time ./lj_sim.py 12 .04 --cython
 =========== 
 LJ clusters 
 ===========
Particles: 69 | Temp: 1.000000 | Steps: 100 | dt: 0.002000 | thermo: 10
integrate      0.1567
    force_list 0.1297
    tot_PE     0.0080
init           0.0005
    tot_PE     0.0002
        0.58 real         0.50 user         0.07 sys
```
